### PR TITLE
Add Seattle Fire 911 analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ htmlcov/
 backend/.env.development
 backend/.env.test
 backend/.env.production
+
+typings

--- a/backend/.env.development.example
+++ b/backend/.env.development.example
@@ -8,6 +8,18 @@
 DATABRICKS_HOST=https://your-workspace.azuredatabricks.net
 DATABRICKS_TOKEN=your-databricks-token
 
+# Analytics datasource. The DataSource factory in backend/datasource/__init__.py
+# selects an implementation based on DATA_SOURCE. Only "databricks" is wired
+# today; the protocol leaves room for postgres/bigquery/etc.
+DATA_SOURCE=databricks
+
+# Databricks SQL warehouse path, used by the analytics router for catalog
+# queries. Separate from the serving endpoint that powers the emotion demo.
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/your-warehouse-id
+
+# Fully-qualified table for Seattle Fire 911 calls analytics.
+SEATTLE_FIRE_911_TABLE=seattle_data.seattle_bronze.seattle_fire_911_calls
+
 # Sentry. Leave blank to disable error reporting in local dev.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -6,6 +6,11 @@
 DATABRICKS_HOST=https://your-workspace.azuredatabricks.net
 DATABRICKS_TOKEN=your-databricks-token
 
+# Analytics datasource configuration. See backend/datasource/__init__.py.
+DATA_SOURCE=databricks
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/your-warehouse-id
+SEATTLE_FIRE_911_TABLE=seattle_data.seattle_bronze.seattle_fire_911_calls
+
 # Sentry. Bump sample rates here to ship traces from prod.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -5,6 +5,12 @@
 DATABRICKS_HOST=https://test.invalid
 DATABRICKS_TOKEN=test-token
 
+# Analytics datasource. Tests should override the FastAPI dependency to inject
+# a FakeDataSource rather than relying on a live SQL warehouse.
+DATA_SOURCE=databricks
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/test
+SEATTLE_FIRE_911_TABLE=seattle_data.seattle_bronze.seattle_fire_911_calls
+
 # Sentry off in tests so failing tests do not page anyone.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0

--- a/backend/analytics/queries.py
+++ b/backend/analytics/queries.py
@@ -1,0 +1,22 @@
+"""SQL strings for the analytics router.
+
+Keep queries here, not inline in service.py, so a future port to another
+warehouse only touches this module. ANSI where possible; date/time
+functions are the main thing that varies between dialects, so prefer
+EXTRACT(... FROM CAST(col AS TIMESTAMP)) over vendor-specific helpers.
+
+The Seattle Fire 911 calls table is in the bronze layer with all columns
+typed as strings; cast `datetime` to TIMESTAMP before extracting parts.
+Datetime values are ISO 8601 with millisecond precision (e.g.
+"2026-03-09T08:42:00.000") which CAST handles natively.
+
+Identifiers (table names) cannot be parameterized through the driver, so
+they are interpolated from trusted env vars at query-build time. Values
+that come from request input MUST go through `params` instead.
+"""
+
+from __future__ import annotations
+
+
+def fire_911_row_count(table: str) -> str:
+    return f"SELECT COUNT(*) AS row_count FROM {table}"

--- a/backend/analytics/router.py
+++ b/backend/analytics/router.py
@@ -1,0 +1,44 @@
+"""FastAPI router for analytics endpoints.
+
+Mounted from backend/main.py at app construction. Each endpoint depends
+on `_datasource_dep`, which tests override with a FakeDataSource so no
+network is required.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.datasource import DataSource, get_datasource
+
+from . import service
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+
+def _datasource_dep() -> DataSource:
+    return get_datasource()
+
+class SeattleFire911MetadataResponse(BaseModel):
+    table: str
+    rowCount: int
+    fetchedAt: str
+    
+@router.get("/seattle-fire-911/metadata", response_model=SeattleFire911MetadataResponse)
+def seattle_fire_911_metadata(ds: DataSource = Depends(_datasource_dep)) -> SeattleFire911MetadataResponse:
+    try:
+        return service.fire_911_metadata(ds)
+    except RuntimeError as exc:
+        # Configuration error: missing env var. 503 because the service
+        # could become ready without a code change.
+        logger.warning("Analytics misconfigured: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc))
+    except Exception:
+        logger.exception("Failed to query Seattle Fire 911 metadata")
+        raise HTTPException(status_code=502, detail="Upstream analytics query failed")

--- a/backend/analytics/service.py
+++ b/backend/analytics/service.py
@@ -1,0 +1,52 @@
+"""Cached query functions for the analytics router.
+
+Each function takes a DataSource (so tests can inject a FakeDataSource),
+runs a small aggregation, and caches the result in a process-local
+TTLCache. The cache key includes the resolved table name so a swap of
+SEATTLE_FIRE_911_TABLE between deploys does not return stale rows.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from cachetools import TTLCache
+
+from backend.datasource import DataSource
+
+from . import queries
+
+_CACHE_TTL_SECONDS = 15 * 60
+_metadata_cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=8, ttl=_CACHE_TTL_SECONDS)
+
+
+def _fire_911_table() -> str:
+    table = os.environ.get("SEATTLE_FIRE_911_TABLE")
+    if not table:
+        raise RuntimeError("SEATTLE_FIRE_911_TABLE is not configured")
+    return table
+
+
+def fire_911_metadata(ds: DataSource) -> dict[str, Any]:
+    """Row count + table identifier + when this data was last pulled."""
+    table = _fire_911_table()
+    cached = _metadata_cache.get(table)
+    if cached is not None:
+        return cached
+
+    rows = ds.execute(queries.fire_911_row_count(table))
+    row_count = int(rows[0]["row_count"]) if rows else 0
+    result: dict[str, Any] = {
+        "table": table,
+        "rowCount": row_count,
+        "fetchedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    _metadata_cache[table] = result
+    return result
+
+
+def clear_caches() -> None:
+    """For tests. Production code should rely on the TTL."""
+    _metadata_cache.clear()

--- a/backend/datasource/__init__.py
+++ b/backend/datasource/__init__.py
@@ -1,0 +1,50 @@
+"""Analytics datasource factory.
+
+Selects an implementation of the DataSource protocol based on the DATA_SOURCE
+env var. Only "databricks" is wired today, but the seam is here so future
+backends (postgres, bigquery, sqlite) can drop in without touching the
+analytics router/service layer.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from .base import DataSource
+from .databricks import DatabricksDataSource
+
+_datasource: DataSource | None = None
+
+
+_REGISTRY: dict[str, Callable[[], DataSource]] = {
+    "databricks": DatabricksDataSource,
+}
+
+
+def get_datasource() -> DataSource:
+    """Return the process-wide DataSource singleton.
+
+    Lazy so importing this module does not open a connection at startup
+    (matters for tests, which override the FastAPI dependency before any
+    real query runs).
+    """
+    global _datasource
+    if _datasource is None:
+        name = os.environ.get("DATA_SOURCE", "databricks").lower()
+        factory = _REGISTRY.get(name)
+        if factory is None:
+            raise RuntimeError(
+                f"Unknown DATA_SOURCE '{name}'. Known: {sorted(_REGISTRY)}",
+            )
+        _datasource = factory()
+    return _datasource
+
+
+def reset_datasource() -> None:
+    """Drop the cached singleton. For tests and env-change scenarios."""
+    global _datasource
+    _datasource = None
+
+
+__all__ = ["DataSource", "get_datasource", "reset_datasource"]

--- a/backend/datasource/base.py
+++ b/backend/datasource/base.py
@@ -1,0 +1,26 @@
+"""DataSource protocol shared by all analytics backends.
+
+The protocol is intentionally minimal: one `execute` method that returns a
+list of dicts. Dialect differences (date functions, identifier quoting,
+LIMIT vs TOP) leak through any abstraction, so they live in the SQL
+strings in backend/analytics/queries.py, not here.
+
+Parameter style is named (:foo), matching databricks-sql-connector's
+paramstyle="named". Future implementations are responsible for translating
+to their driver's paramstyle if it differs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DataSource(Protocol):
+    def execute(
+        self,
+        sql: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run a read query and return rows as dicts keyed by column name."""
+        ...

--- a/backend/datasource/databricks.py
+++ b/backend/datasource/databricks.py
@@ -1,0 +1,55 @@
+"""Databricks SQL warehouse implementation of the DataSource protocol.
+
+Uses databricks-sql-connector (not the WorkspaceClient SDK used elsewhere
+in main.py for serving endpoints). The two are separate Databricks
+integrations with different config: serving endpoints need host+token,
+SQL warehouses additionally need an HTTP path.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from databricks import sql
+
+
+def _hostname(host: str) -> str:
+    # The connector wants a bare hostname, not a URL. Accept either.
+    if "://" in host:
+        return urlparse(host).hostname or host
+    return host
+
+
+class DatabricksDataSource:
+    """Opens a fresh connection per query.
+
+    Pooling could come later, but at the scale of a portfolio site the
+    cache layer in backend/analytics/service.py absorbs almost all traffic,
+    so the cost of repeated connects is negligible.
+    """
+
+    def execute(
+        self,
+        sql_text: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        host = os.environ.get("DATABRICKS_HOST")
+        token = os.environ.get("DATABRICKS_TOKEN")
+        http_path = os.environ.get("DATABRICKS_HTTP_PATH")
+        if not host or not token or not http_path:
+            raise RuntimeError(
+                "Databricks SQL warehouse is not configured. "
+                "Set DATABRICKS_HOST, DATABRICKS_TOKEN, DATABRICKS_HTTP_PATH.",
+            )
+
+        with sql.connect(
+            server_hostname=_hostname(host),
+            http_path=http_path,
+            access_token=token,
+        ) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(sql_text, parameters=dict(params or {}))
+                columns = [c[0] for c in cursor.description or []]
+                return [dict(zip(columns, row)) for row in cursor.fetchall()]

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,8 @@ from fastapi.responses import JSONResponse
 import sentry_sdk
 from fastapi_mail import FastMail, MessageSchema, ConnectionConfig, MessageType
 
+from backend.analytics.router import router as analytics_router
+
 
 # Each tier has independent dev/test/prod envs. APP_ENV selects which
 # backend/.env.<env> file to layer on top of the process environment. Values
@@ -47,6 +49,8 @@ app = FastAPI(title="Simple FastAPI + React App")
 limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
 app.state.limiter = limiter
 app.add_middleware(SlowAPIMiddleware)
+
+app.include_router(analytics_router)
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/backend/main.py
+++ b/backend/main.py
@@ -190,10 +190,9 @@ class ContactPayload(BaseModel):
 
 @app.post("/api/contact")
 @limiter.limit("5/minute")
-async def contact(request: Request, payload: ContactPayload) -> JSONResponse:
+async def contact(request: Request, payload: ContactPayload) -> dict[str, str]:
     
     try: 
-
         mail_config = ConnectionConfig(
             MAIL_USERNAME=os.environ["MAIL_USERNAME"],
             MAIL_PASSWORD=SecretStr(os.environ["MAIL_PASSWORD"]),
@@ -215,7 +214,7 @@ async def contact(request: Request, payload: ContactPayload) -> JSONResponse:
     except Exception:
         logger.exception("Error sending contact email")
         raise HTTPException(status_code=500, detail="Failed to send message")
-    return JSONResponse(content={"status": "success"})
+    return {"status": "success"}
 
 static_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "static"))
 os.makedirs(static_dir, exist_ok=True)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ const RagDemoPage = lazy(() => import('./pages/RagDemoPage'));
 const EnergyOptimizationPage = lazy(() => import('./pages/EnergyOptimizationPage'));
 const CloudMigrationPage = lazy(() => import('./pages/CloudMigrationPage'));
 const AboutPage = lazy(() => import('./pages/AboutPage'));
+const AnalyticsHubPage = lazy(() => import('./pages/AnalyticsHubPage'));
+const SeattleFire911Page = lazy(() => import('./pages/SeattleFire911Page'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 function App() {
@@ -36,6 +38,8 @@ function App() {
                   <Route path={ROUTES.energyOptimization} element={<EnergyOptimizationPage />} />
                   <Route path={ROUTES.cloudMigration} element={<CloudMigrationPage />} />
                   <Route path={ROUTES.about} element={<AboutPage />} />
+                  <Route path={ROUTES.analyticsHub} element={<AnalyticsHubPage />} />
+                  <Route path={ROUTES.seattleFire911} element={<SeattleFire911Page />} />
                   <Route path="*" element={<NotFoundPage />} />
                 </Route>
               </Routes>

--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './client';
+
+export interface Fire911Metadata {
+  table: string;
+  rowCount: number;
+  fetchedAt: string;
+}
+
+const fetchFire911Metadata = async (signal?: AbortSignal): Promise<Fire911Metadata> => {
+  const json = await apiFetch<Fire911Metadata>(
+    '/api/analytics/seattle-fire-911/metadata',
+    { signal },
+  );
+  if (!json) throw new Error('Empty response from /api/analytics/seattle-fire-911/metadata');
+  return json;
+};
+
+export const useFire911Metadata = () =>
+  useQuery({
+    queryKey: ['analytics', 'seattle-fire-911', 'metadata'],
+    queryFn: ({ signal }) => fetchFire911Metadata(signal),
+    // Backend caches for 15 minutes; client can keep results fresh that long too.
+    // Retry policy is inherited from the QueryClient default in main.tsx.
+    staleTime: 15 * 60 * 1000,
+  });

--- a/frontend/src/components/Navigation/Navigation.tsx
+++ b/frontend/src/components/Navigation/Navigation.tsx
@@ -12,6 +12,7 @@ interface NavigationProps {
 const NAV_ITEMS = [
   { to: ROUTES.home, label: 'Home' },
   { to: ROUTES.projects, label: 'Projects' },
+  { to: ROUTES.analyticsHub, label: 'Analytics' },
   { to: ROUTES.about, label: 'About' },
 ] as const;
 

--- a/frontend/src/components/Navigation/__tests__/Navigation.test.tsx
+++ b/frontend/src/components/Navigation/__tests__/Navigation.test.tsx
@@ -23,6 +23,7 @@ describe('Navigation', () => {
     renderNavigation();
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Projects' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute('href', '/analytics');
     expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument();
   });
 

--- a/frontend/src/data/routes.ts
+++ b/frontend/src/data/routes.ts
@@ -7,6 +7,8 @@ export const ROUTES = {
   energyOptimization: '/projects/energy-optimization',
   cloudMigration: '/projects/cloud-migration',
   about: '/about',
+  analyticsHub: '/analytics',
+  seattleFire911: '/analytics/seattle-fire-911',
 } as const;
 
 export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];

--- a/frontend/src/pages/AnalyticsHubPage/AnalyticsHubPage.module.css
+++ b/frontend/src/pages/AnalyticsHubPage/AnalyticsHubPage.module.css
@@ -1,0 +1,74 @@
+.analytics-hub-page {
+  min-height: 100vh;
+  min-height: 100dvh;
+  background-color: var(--color-bg-subtle);
+}
+
+.section-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.datasets-section {
+  padding: 4rem 0;
+}
+
+.datasets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dataset-card {
+  display: block;
+  padding: 1.75rem;
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dataset-card:hover,
+.dataset-card:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--color-accent);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.dataset-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.25rem;
+}
+
+.dataset-blurb {
+  margin: 0 0 1rem 0;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.dataset-source {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.dataset-source-label {
+  font-weight: 600;
+}
+
+.dataset-source code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-all;
+}
+
+@media (max-width: 768px) {
+  .section-container {
+    padding: 0 1.25rem;
+  }
+}

--- a/frontend/src/pages/AnalyticsHubPage/AnalyticsHubPage.tsx
+++ b/frontend/src/pages/AnalyticsHubPage/AnalyticsHubPage.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Seo from '../../components/Seo';
+import Hero from '../../components/Hero/Hero';
+import { ROUTES } from '../../data/routes';
+import styles from './AnalyticsHubPage.module.css';
+
+interface Dataset {
+  title: string;
+  blurb: string;
+  to: string;
+  source: string;
+}
+
+const DATASETS: readonly Dataset[] = [
+  {
+    title: 'Seattle Fire 911 Calls',
+    blurb:
+      'Dispatch records from the Seattle Fire Department. Volume by time of day, day of week, and call type.',
+    to: ROUTES.seattleFire911,
+    source: 'seattle_data.seattle_bronze.seattle_fire_911_calls',
+  },
+] as const;
+
+const AnalyticsHubPage: React.FC = () => {
+  return (
+    <div className={styles.analyticsHubPage}>
+      <Seo
+        title="Analytics"
+        description="Public-data analytics dashboards by Ian Edmundson, starting with Seattle Fire Department 911 call records."
+      />
+      <main className="main-content">
+        <Hero
+          title="Analytics"
+          subtitle="Dashboards over public datasets, refreshed by a separate ingestion pipeline and queried live from the warehouse."
+        />
+
+        <section className={styles.datasetsSection}>
+          <div className={styles.sectionContainer}>
+            <ul className={styles.datasetsGrid}>
+              {DATASETS.map((d) => (
+                <li key={d.to}>
+                  <Link to={d.to} className={styles.datasetCard}>
+                    <h2 className={styles.datasetTitle}>{d.title}</h2>
+                    <p className={styles.datasetBlurb}>{d.blurb}</p>
+                    <p className={styles.datasetSource}>
+                      <span className={styles.datasetSourceLabel}>Source: </span>
+                      <code>{d.source}</code>
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default AnalyticsHubPage;

--- a/frontend/src/pages/AnalyticsHubPage/__tests__/AnalyticsHubPage.test.tsx
+++ b/frontend/src/pages/AnalyticsHubPage/__tests__/AnalyticsHubPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AnalyticsHubPage from '../AnalyticsHubPage';
+
+describe('AnalyticsHubPage', () => {
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <AnalyticsHubPage />
+      </MemoryRouter>,
+    );
+
+  it('renders the hero title', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { level: 1, name: 'Analytics' })).toBeInTheDocument();
+  });
+
+  it('renders a card linking to the Seattle Fire 911 page', () => {
+    renderPage();
+    const link = screen.getByRole('link', { name: /Seattle Fire 911 Calls/i });
+    expect(link).toHaveAttribute('href', '/analytics/seattle-fire-911');
+  });
+
+  it('shows the source table identifier for context', () => {
+    renderPage();
+    expect(
+      screen.getByText('seattle_data.seattle_bronze.seattle_fire_911_calls'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AnalyticsHubPage/index.ts
+++ b/frontend/src/pages/AnalyticsHubPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AnalyticsHubPage';

--- a/frontend/src/pages/SeattleFire911Page/SeattleFire911Page.module.css
+++ b/frontend/src/pages/SeattleFire911Page/SeattleFire911Page.module.css
@@ -1,0 +1,88 @@
+.seattle-fire911-page {
+  min-height: 100vh;
+  min-height: 100dvh;
+  background-color: var(--color-bg-subtle);
+}
+
+.section-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.source-section,
+.placeholder-section {
+  padding: 3rem 0;
+}
+
+.section-title {
+  margin: 0 0 1.5rem 0;
+  font-size: 1.5rem;
+}
+
+.source-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1.5rem;
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.source-row dt {
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.source-row dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.source-row code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.95em;
+}
+
+.status-message {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.placeholder-text {
+  color: var(--color-text-muted);
+  line-height: 1.6;
+  margin: 0 0 1.5rem 0;
+}
+
+.back-link {
+  margin: 0;
+}
+
+.back-link a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.back-link a:hover,
+.back-link a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .section-container {
+    padding: 0 1.25rem;
+  }
+  .source-row {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+}

--- a/frontend/src/pages/SeattleFire911Page/SeattleFire911Page.tsx
+++ b/frontend/src/pages/SeattleFire911Page/SeattleFire911Page.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Seo from '../../components/Seo';
+import Hero from '../../components/Hero/Hero';
+import { useFire911Metadata } from '../../api/analytics';
+import { ROUTES } from '../../data/routes';
+import styles from './SeattleFire911Page.module.css';
+
+const formatRowCount = (n: number) => n.toLocaleString('en-US');
+
+const formatFetchedAt = (iso: string) => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+};
+
+const SeattleFire911Page: React.FC = () => {
+  const { data, isLoading, error } = useFire911Metadata();
+
+  return (
+    <div className={styles.seattleFire911Page}>
+      <Seo
+        title="Seattle Fire 911 Calls"
+        description="Live analytics over Seattle Fire Department 911 dispatch records, queried from a Databricks warehouse."
+      />
+      <main className="main-content">
+        <Hero
+          title="Seattle Fire 911 Calls"
+          subtitle="Seattle Fire Department dispatch volume from the bronze-layer warehouse table. Refreshed by a separate ingestion pipeline."
+        />
+
+        <section className={styles.sourceSection} aria-labelledby="source-heading">
+          <div className={styles.sectionContainer}>
+            <h2 id="source-heading" className={styles.sectionTitle}>Source</h2>
+
+            {isLoading && (
+              <p className={styles.statusMessage} aria-busy="true">
+                Loading source metadata...
+              </p>
+            )}
+
+            {error && (
+              <p className={styles.statusMessage} role="alert">
+                Could not load source metadata. The warehouse may be unavailable or
+                misconfigured.
+              </p>
+            )}
+
+            {data && (
+              <dl className={styles.sourceList}>
+                <div className={styles.sourceRow}>
+                  <dt>Table</dt>
+                  <dd><code>{data.table}</code></dd>
+                </div>
+                <div className={styles.sourceRow}>
+                  <dt>Row count</dt>
+                  <dd>{formatRowCount(data.rowCount)}</dd>
+                </div>
+                <div className={styles.sourceRow}>
+                  <dt>Fetched at</dt>
+                  <dd>{formatFetchedAt(data.fetchedAt)}</dd>
+                </div>
+              </dl>
+            )}
+          </div>
+        </section>
+
+        <section className={styles.placeholderSection} aria-labelledby="placeholder-heading">
+          <div className={styles.sectionContainer}>
+            <h2 id="placeholder-heading" className={styles.sectionTitle}>Charts</h2>
+            <p className={styles.placeholderText}>
+              Aggregations land in the next iteration: calls by hour of day, day of week,
+              month, and call type.
+            </p>
+            <p className={styles.backLink}>
+              <Link to={ROUTES.analyticsHub}>Back to analytics</Link>
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default SeattleFire911Page;

--- a/frontend/src/pages/SeattleFire911Page/__tests__/SeattleFire911Page.test.tsx
+++ b/frontend/src/pages/SeattleFire911Page/__tests__/SeattleFire911Page.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, beforeEach, afterEach } from 'vitest';
+import SeattleFire911Page from '../SeattleFire911Page';
+
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <SeattleFire911Page />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe('SeattleFire911Page', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('renders the hero and source heading immediately', () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Seattle Fire 911 Calls' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Source' })).toBeInTheDocument();
+  });
+
+  it('shows the loading state while the metadata request is in flight', () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByText(/loading source metadata/i)).toBeInTheDocument();
+  });
+
+  it('renders the metadata once it loads', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          table: 'cat.schema.fire_911',
+          rowCount: 12345,
+          fetchedAt: '2026-05-20T14:30:00Z',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('cat.schema.fire_911')).toBeInTheDocument();
+    });
+    expect(screen.getByText('12,345')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'down' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/could not load source metadata/i);
+    });
+  });
+
+  it('links back to the analytics hub', () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    const link = screen.getByRole('link', { name: /back to analytics/i });
+    expect(link).toHaveAttribute('href', '/analytics');
+  });
+});

--- a/frontend/src/pages/SeattleFire911Page/index.ts
+++ b/frontend/src/pages/SeattleFire911Page/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SeattleFire911Page';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "aiofiles>=25.1.0",
+    "cachetools>=5.5.0",
     "databricks-sdk>=0.40.0",
+    "databricks-sql-connector>=3.5.0",
     "fastapi>=0.121.3",
     "fastapi-mail>=1.6.2",
     "httpx>=0.28.1",

--- a/tests/test_analytics_router.py
+++ b/tests/test_analytics_router.py
@@ -1,0 +1,59 @@
+from typing import Any, Mapping
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.analytics import service
+from backend.analytics.router import _datasource_dep
+from backend.main import app
+
+
+class FakeDataSource:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self.rows = rows
+
+    def execute(self, sql: str, params: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+        return self.rows
+
+
+@pytest.fixture(autouse=True)
+def _table_env(monkeypatch):
+    monkeypatch.setenv("SEATTLE_FIRE_911_TABLE", "cat.schema.fire_911")
+    service.clear_caches()
+    yield
+    service.clear_caches()
+    app.dependency_overrides.clear()
+
+
+def _client_with(rows: list[dict[str, Any]]) -> TestClient:
+    app.dependency_overrides[_datasource_dep] = lambda: FakeDataSource(rows)
+    return TestClient(app)
+
+
+def test_metadata_endpoint_returns_row_count():
+    client = _client_with([{"row_count": 9999}])
+    response = client.get("/api/analytics/seattle-fire-911/metadata")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["table"] == "cat.schema.fire_911"
+    assert body["rowCount"] == 9999
+    assert "fetchedAt" in body
+
+
+def test_metadata_returns_503_when_table_unconfigured(monkeypatch):
+    monkeypatch.delenv("SEATTLE_FIRE_911_TABLE", raising=False)
+    client = _client_with([{"row_count": 0}])
+    response = client.get("/api/analytics/seattle-fire-911/metadata")
+    assert response.status_code == 503
+    assert "SEATTLE_FIRE_911_TABLE" in response.json()["detail"]
+
+
+def test_metadata_returns_502_on_upstream_failure():
+    class BrokenDataSource:
+        def execute(self, sql: str, params: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+            raise ConnectionError("warehouse offline")
+
+    app.dependency_overrides[_datasource_dep] = lambda: BrokenDataSource()
+    client = TestClient(app)
+    response = client.get("/api/analytics/seattle-fire-911/metadata")
+    assert response.status_code == 502

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,0 +1,62 @@
+from typing import Any, Mapping
+
+import pytest
+
+from backend.analytics import service
+
+
+class FakeDataSource:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self.rows = rows
+        self.calls: list[tuple[str, Mapping[str, Any] | None]] = []
+
+    def execute(self, sql: str, params: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+        self.calls.append((sql, params))
+        return self.rows
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    service.clear_caches()
+    yield
+    service.clear_caches()
+
+
+@pytest.fixture
+def _table_env(monkeypatch):
+    monkeypatch.setenv("SEATTLE_FIRE_911_TABLE", "cat.schema.fire_911")
+
+
+def test_fire_911_metadata_returns_row_count(_table_env):
+    ds = FakeDataSource([{"row_count": 12345}])
+    result = service.fire_911_metadata(ds)
+    assert result["table"] == "cat.schema.fire_911"
+    assert result["rowCount"] == 12345
+    assert "fetchedAt" in result
+
+
+def test_fire_911_metadata_caches_result(_table_env):
+    ds = FakeDataSource([{"row_count": 1}])
+    service.fire_911_metadata(ds)
+    service.fire_911_metadata(ds)
+    assert len(ds.calls) == 1, "second call should be served from the TTLCache"
+
+
+def test_fire_911_metadata_requires_table_env(monkeypatch):
+    monkeypatch.delenv("SEATTLE_FIRE_911_TABLE", raising=False)
+    ds = FakeDataSource([{"row_count": 0}])
+    with pytest.raises(RuntimeError, match="SEATTLE_FIRE_911_TABLE"):
+        service.fire_911_metadata(ds)
+
+
+def test_fire_911_metadata_handles_empty_result(_table_env):
+    ds = FakeDataSource([])
+    result = service.fire_911_metadata(ds)
+    assert result["rowCount"] == 0
+
+
+def test_fire_911_metadata_interpolates_table_into_sql(_table_env):
+    ds = FakeDataSource([{"row_count": 5}])
+    service.fire_911_metadata(ds)
+    sql, _ = ds.calls[0]
+    assert "cat.schema.fire_911" in sql

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend import datasource as ds_module
+from backend.datasource import DataSource, get_datasource, reset_datasource
+from backend.datasource.databricks import DatabricksDataSource, _hostname
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_datasource()
+    yield
+    reset_datasource()
+
+
+def test_factory_returns_databricks_by_default(monkeypatch):
+    monkeypatch.delenv("DATA_SOURCE", raising=False)
+    ds = get_datasource()
+    assert isinstance(ds, DatabricksDataSource)
+
+
+def test_factory_honors_data_source_env(monkeypatch):
+    monkeypatch.setenv("DATA_SOURCE", "databricks")
+    ds = get_datasource()
+    assert isinstance(ds, DatabricksDataSource)
+
+
+def test_factory_rejects_unknown_backend(monkeypatch):
+    monkeypatch.setenv("DATA_SOURCE", "no-such-backend")
+    with pytest.raises(RuntimeError, match="Unknown DATA_SOURCE"):
+        get_datasource()
+
+
+def test_factory_returns_singleton(monkeypatch):
+    monkeypatch.setenv("DATA_SOURCE", "databricks")
+    assert get_datasource() is get_datasource()
+
+
+def test_databricks_impl_satisfies_protocol():
+    # runtime_checkable Protocol: structural check at runtime.
+    assert isinstance(DatabricksDataSource(), DataSource)
+
+
+def test_hostname_strips_scheme():
+    assert _hostname("https://workspace.azuredatabricks.net") == "workspace.azuredatabricks.net"
+    assert _hostname("workspace.azuredatabricks.net") == "workspace.azuredatabricks.net"
+
+
+def test_databricks_execute_requires_credentials(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.delenv("DATABRICKS_HTTP_PATH", raising=False)
+    with pytest.raises(RuntimeError, match="not configured"):
+        DatabricksDataSource().execute("SELECT 1")
+
+
+def test_databricks_execute_returns_dict_rows(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "tok")
+    monkeypatch.setenv("DATABRICKS_HTTP_PATH", "/sql/1.0/warehouses/abc")
+
+    fake_cursor = MagicMock()
+    fake_cursor.description = [("row_count", None)]
+    fake_cursor.fetchall.return_value = [(42,)]
+    fake_cursor.__enter__.return_value = fake_cursor
+    fake_cursor.__exit__.return_value = False
+
+    fake_conn = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    fake_conn.__enter__.return_value = fake_conn
+    fake_conn.__exit__.return_value = False
+
+    with patch("backend.datasource.databricks.sql.connect", return_value=fake_conn) as connect:
+        rows = DatabricksDataSource().execute("SELECT COUNT(*) AS row_count FROM t")
+
+    assert rows == [{"row_count": 42}]
+    connect.assert_called_once_with(
+        server_hostname="workspace.databricks.com",
+        http_path="/sql/1.0/warehouses/abc",
+        access_token="tok",
+    )
+    fake_cursor.execute.assert_called_once_with("SELECT COUNT(*) AS row_count FROM t", parameters={})
+
+
+def test_reset_datasource_clears_singleton(monkeypatch):
+    monkeypatch.setenv("DATA_SOURCE", "databricks")
+    first = get_datasource()
+    ds_module.reset_datasource()
+    second = get_datasource()
+    assert first is not second

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
 
@@ -63,6 +65,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c1/67cfb86aa21144796ff51068326d467fbef8ee42f8d08a3a8a926106cf0c/cachetools-7.1.3.tar.gz", hash = "sha256:135cfe944bc3c1e805505f65dae0bef375a2f96261171ab66c79ef77d0bda39d", size = 45780, upload-time = "2026-05-18T18:21:03.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/52/8ff5c1a3b2e821ced9b2998fba3ee29aa4525c0bf51e5ee55dd6f61a4ed5/cachetools-7.1.3-py3-none-any.whl", hash = "sha256:9876787e2346e20584d5cca236cb5d49d04e7193de91646f230725b2e1e8b804", size = 16763, upload-time = "2026-05-18T18:21:02.386Z" },
 ]
 
 [[package]]
@@ -326,6 +337,27 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sql-connector"
+version = "4.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lz4" },
+    { name = "oauthlib" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "pybreaker" },
+    { name = "pyjwt" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "thrift" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/2f/2c1a96b1d40d53dc9a0abf639c823895b6da76b1b5dc2f2230df2ae1aa6c/databricks_sql_connector-4.2.6.tar.gz", hash = "sha256:65e59f08e55dcc563c05e02e2321d5171dd9482e5792328d99ac097377795d01", size = 189069, upload-time = "2026-04-23T10:40:33.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/4f/4ea282af1e413d26e47b9e987c1cbef1d3fc599da81eb54ac2bf74b6b822/databricks_sql_connector-4.2.6-py3-none-any.whl", hash = "sha256:61e0f425c990a0ec52c31165ea7dd0582cc0ad90c5fbd5fc9bea59bb38faeb00", size = 216743, upload-time = "2026-04-23T10:40:32.216Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -357,6 +389,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -452,7 +493,9 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "cachetools" },
     { name = "databricks-sdk" },
+    { name = "databricks-sql-connector" },
     { name = "fastapi" },
     { name = "fastapi-mail" },
     { name = "httpx" },
@@ -474,7 +517,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "cachetools", specifier = ">=5.5.0" },
     { name = "databricks-sdk", specifier = ">=0.40.0" },
+    { name = "databricks-sql-connector", specifier = ">=3.5.0" },
     { name = "fastapi", specifier = ">=0.121.3" },
     { name = "fastapi-mail", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -559,6 +604,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/90/bfd7a6fab22bdfafe48ed3c4831713cb77b4779d18ade5e248d5dbc0ca22/logistro-2.0.1.tar.gz", hash = "sha256:8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047", size = 8398, upload-time = "2025-11-01T02:41:18.81Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl", hash = "sha256:06ffa127b9fb4ac8b1972ae6b2a9d7fde57598bf5939cd708f43ec5bba2d31eb", size = 8555, upload-time = "2025-11-01T02:41:17.587Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/5b/6edcd23319d9e28b1bedf32768c3d1fd56eed8223960a2c47dacd2cec2af/lz4-4.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6da84a26b3aa5da13a62e4b89ab36a396e9327de8cd48b436a3467077f8ccd4", size = 207391, upload-time = "2025-11-03T13:01:36.644Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/5f9b772e85b3d5769367a79973b8030afad0d6b724444083bad09becd66f/lz4-4.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61d0ee03e6c616f4a8b69987d03d514e8896c8b1b7cc7598ad029e5c6aedfd43", size = 207146, upload-time = "2025-11-03T13:01:37.928Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/f66da5647c0d72592081a37c8775feacc3d14d2625bbdaabd6307c274565/lz4-4.4.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:33dd86cea8375d8e5dd001e41f321d0a4b1eb7985f39be1b6a4f466cd480b8a7", size = 1292623, upload-time = "2025-11-03T13:01:39.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fc/5df0f17467cdda0cad464a9197a447027879197761b55faad7ca29c29a04/lz4-4.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609a69c68e7cfcfa9d894dc06be13f2e00761485b62df4e2472f1b66f7b405fb", size = 1279982, upload-time = "2025-11-03T13:01:40.816Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3b/b55cb577aa148ed4e383e9700c36f70b651cd434e1c07568f0a86c9d5fbb/lz4-4.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75419bb1a559af00250b8f1360d508444e80ed4b26d9d40ec5b09fe7875cb989", size = 1368674, upload-time = "2025-11-03T13:01:42.118Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/31/e97e8c74c59ea479598e5c55cbe0b1334f03ee74ca97726e872944ed42df/lz4-4.4.5-cp311-cp311-win32.whl", hash = "sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d", size = 88168, upload-time = "2025-11-03T13:01:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/18/47/715865a6c7071f417bef9b57c8644f29cb7a55b77742bd5d93a609274e7e/lz4-4.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:8a842ead8ca7c0ee2f396ca5d878c4c40439a527ebad2b996b0444f0074ed004", size = 99491, upload-time = "2025-11-03T13:01:44.167Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e7/ac120c2ca8caec5c945e6356ada2aa5cfabd83a01e3170f264a5c42c8231/lz4-4.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:83bc23ef65b6ae44f3287c38cbf82c269e2e96a26e560aa551735883388dcc4b", size = 91271, upload-time = "2025-11-03T13:01:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
 ]
 
 [[package]]
@@ -723,6 +816,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/e4/68d2f474df2cb671b2b6c2986a02e520671295647dad82484cde80ca427b/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffac52f28a7849ad7576293c0cb7b9f08304e8f7d738a8cb8a90ec4c55a998eb", size = 14391768, upload-time = "2025-11-16T22:52:33.593Z" },
     { url = "https://files.pythonhosted.org/packages/b8/50/94ccd8a2b141cb50651fddd4f6a48874acb3c91c8f0842b08a6afc4b0b21/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63c0e9e7eea69588479ebf4a8a270d5ac22763cc5854e9a7eae952a3908103f7", size = 16729263, upload-time = "2025-11-16T22:52:36.369Z" },
     { url = "https://files.pythonhosted.org/packages/2d/ee/346fa473e666fe14c52fcdd19ec2424157290a032d4c41f98127bfb31ac7/numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425", size = 12967213, upload-time = "2025-11-16T22:52:39.38Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -1010,6 +1124,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1156,6 +1279,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -1469,6 +1601,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
 ]
+
+[[package]]
+name = "thrift"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/c2/db648cc10dd7d15560f2eafd92a27cd280811924696e0b4a87175fb28c94/thrift-0.22.0.tar.gz", hash = "sha256:42e8276afbd5f54fe1d364858b6877bc5e5a4a5ed69f6a005b94ca4918fe1466", size = 62303, upload-time = "2025-05-23T20:49:33.309Z" }
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary
- New DataSource Protocol with a Databricks SQL implementation, lazy singleton factory selected by DATA_SOURCE env var
- New /api/analytics/seattle-fire-911/metadata endpoint with 15-minute TTL cache on results
- New /analytics hub page and /analytics/seattle-fire-911 detail page, both lazy loaded
- Tidy: contact endpoint returns dict[str, str] instead of wrapping in JSONResponse

## Test plan
- [ ] Backend: .venv/bin/pytest tests/test_datasource.py tests/test_analytics_router.py tests/test_analytics_service.py
- [ ] Frontend: npm run typecheck && npm run lint && npm test
- [ ] Manual: hit /analytics and /analytics/seattle-fire-911 in the dev server, confirm metadata loads