### PR TITLE
Type analytics metadata response with Pydantic model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Subdirectories with their own conventions have their own `CLAUDE.md`:
 
-- `backend/CLAUDE.md` — Databricks model gotcha, SPA static-file fallback, backend test layout
+- `backend/CLAUDE.md` — Databricks model gotcha, SPA static-file fallback, response model and schemas convention, backend test layout
 
 ## Commands
 
@@ -108,6 +108,6 @@ Frontend and backend each have independent `development`, `test`, and `productio
 
 ### Adding a backend-dependent feature
 
-1. Add the FastAPI route under `/api/*` in `backend/main.py` (or a router module).
+1. Add the FastAPI route under `/api/*` in a feature module (`backend/<feature>/router.py`). Define request/response Pydantic models in `backend/<feature>/schemas.py` and have the service layer return typed models so FastAPI infers the response shape from the return annotation. See `backend/CLAUDE.md` for the full convention.
 2. Wire the UI to the relative `/api/*` path via `frontend/src/api/`. The Vite proxy handles dev, the SPA fallback handles prod.
 3. If the feature isn't ready or you want a kill switch, add a `VITE_ENABLE_<NAME>` flag (default `false` in `.env.{mode}`, set `true` in the Dockerfile build stage when shipping it on). Otherwise no flag is needed: the fullstack image always has the backend present.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -14,6 +14,14 @@ Loaded when working under `backend/`. Root context is in the top-level `CLAUDE.m
 
 **Do not replace this with `StaticFiles.mount` — it breaks SPA fallback.** If you need to add static behavior, layer it on top of the catch-all, don't swap it out.
 
+## API response models and schemas
+
+Each feature module owns its Pydantic models in `<feature>/schemas.py` (see `backend/analytics/schemas.py`). The service layer constructs and returns the typed model; the router annotates the return type and lets FastAPI infer `response_model` from it. Don't set both `response_model=` on the decorator and a typed return annotation: pick the annotation, since the function signature is closer to the data.
+
+When a service caches its results, the cache type follows the model: `TTLCache[str, MyResponse]`, not `TTLCache[str, dict]`.
+
+Tests assert via attribute access (`result.field`), not dict subscript. Pydantic models are not subscriptable.
+
 ## Tests
 
 pytest, repo-root `tests/`, one `test_<module>.py` per backend module. Before declaring a backend change done, run `.venv/bin/pytest tests/` for the affected module — not just the test file you edited. Module-level runs catch fixture and import-order regressions that file-scoped runs miss.

--- a/backend/analytics/router.py
+++ b/backend/analytics/router.py
@@ -15,22 +15,16 @@ from backend.datasource import DataSource, get_datasource
 
 from . import service
 
-from pydantic import BaseModel
+from .schemas import SeattleFire911MetadataResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 
-
 def _datasource_dep() -> DataSource:
     return get_datasource()
-
-class SeattleFire911MetadataResponse(BaseModel):
-    table: str
-    rowCount: int
-    fetchedAt: str
     
-@router.get("/seattle-fire-911/metadata", response_model=SeattleFire911MetadataResponse)
+@router.get("/seattle-fire-911/metadata")
 def seattle_fire_911_metadata(ds: DataSource = Depends(_datasource_dep)) -> SeattleFire911MetadataResponse:
     try:
         return service.fire_911_metadata(ds)

--- a/backend/analytics/schemas.py
+++ b/backend/analytics/schemas.py
@@ -1,0 +1,14 @@
+"""Pydantic models for analytics API requests and responses.
+
+Importing from this module is safe from any layer (router, service, tests).
+Models live here so they can be reused without circular imports.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+class SeattleFire911MetadataResponse(BaseModel):
+    table: str
+    rowCount: int
+    fetchedAt: str

--- a/backend/analytics/service.py
+++ b/backend/analytics/service.py
@@ -18,8 +18,10 @@ from backend.datasource import DataSource
 
 from . import queries
 
+from .schemas import SeattleFire911MetadataResponse
+
 _CACHE_TTL_SECONDS = 15 * 60
-_metadata_cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=8, ttl=_CACHE_TTL_SECONDS)
+_metadata_cache: TTLCache[str, SeattleFire911MetadataResponse] = TTLCache(maxsize=8, ttl=_CACHE_TTL_SECONDS)
 
 
 def _fire_911_table() -> str:
@@ -29,23 +31,26 @@ def _fire_911_table() -> str:
     return table
 
 
-def fire_911_metadata(ds: DataSource) -> dict[str, Any]:
+def fire_911_metadata(ds: DataSource) -> SeattleFire911MetadataResponse:
     """Row count + table identifier + when this data was last pulled."""
     table = _fire_911_table()
+    
     cached = _metadata_cache.get(table)
+    
     if cached is not None:
         return cached
 
     rows = ds.execute(queries.fire_911_row_count(table))
+    
     row_count = int(rows[0]["row_count"]) if rows else 0
-    result: dict[str, Any] = {
-        "table": table,
-        "rowCount": row_count,
-        "fetchedAt": datetime.now(timezone.utc).isoformat(),
-    }
+    
+    result = SeattleFire911MetadataResponse(
+        table=table, rowCount=row_count, fetchedAt=datetime.now(timezone.utc).isoformat()
+    )
+    
     _metadata_cache[table] = result
+    
     return result
-
 
 def clear_caches() -> None:
     """For tests. Production code should rely on the TTL."""

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -30,9 +30,9 @@ def _table_env(monkeypatch):
 def test_fire_911_metadata_returns_row_count(_table_env):
     ds = FakeDataSource([{"row_count": 12345}])
     result = service.fire_911_metadata(ds)
-    assert result["table"] == "cat.schema.fire_911"
-    assert result["rowCount"] == 12345
-    assert "fetchedAt" in result
+    assert result.table == "cat.schema.fire_911"
+    assert result.rowCount == 12345
+    assert result.fetchedAt
 
 
 def test_fire_911_metadata_caches_result(_table_env):
@@ -52,7 +52,7 @@ def test_fire_911_metadata_requires_table_env(monkeypatch):
 def test_fire_911_metadata_handles_empty_result(_table_env):
     ds = FakeDataSource([])
     result = service.fire_911_metadata(ds)
-    assert result["rowCount"] == 0
+    assert result.rowCount == 0
 
 
 def test_fire_911_metadata_interpolates_table_into_sql(_table_env):


### PR DESCRIPTION
## Summary
- New backend/analytics/schemas.py with SeattleFire911MetadataResponse
- Service layer constructs and returns the typed model; cache holds it too
- Router annotation carries the response shape, dropping the redundant response_model kwarg
- Service tests updated for attribute access
- Document the per-feature schemas convention in backend/CLAUDE.md and reference from root CLAUDE.md

## Test plan
- [x] .venv/bin/pytest tests/ -v
- [x] Manual: hit /api/analytics/seattle-fire-911/metadata, confirm JSON shape unchanged from main